### PR TITLE
Fixing confusion of kinetic and total energy

### DIFF
--- a/MiniScatter.cc
+++ b/MiniScatter.cc
@@ -106,7 +106,7 @@ int main(int argc,char** argv) {
 
     G4double world_size          = 0.0;       // World size X/Y [mm]
 
-    G4double beam_energy = 200;               // Beam energy [MeV]
+    G4double beam_energy = 200;               // Beam kinetic energy [MeV]
     G4double beam_eFlat_min = -1.0;           // For flat-spectrum energy distribution,
     G4double beam_eFlat_max = -1.0;           //  set these to min/max, both > 0.0.
 
@@ -315,7 +315,7 @@ int main(int argc,char** argv) {
                 beam_energy = std::stod(string(optarg));
             }
             catch (const std::invalid_argument& ia) {
-                G4cout << "Invalid argument when reading beam energy" << G4endl
+                G4cout << "Invalid argument when reading beam kinetic energy" << G4endl
                        << "Got: '" << optarg << "'" << G4endl
                        << "Expected a floating point number! (exponential notation is accepted)" << G4endl;
                 exit(1);
@@ -805,10 +805,10 @@ void printHelp(G4double target_thick,
             G4cout << "-n <int>    : Run a given number of events automatically"
                    << G4endl;
 
-            G4cout << "-e <double> : Beam energy [MeV],      default/current value = "
+            G4cout << "-e <double> : Beam kinetic energy [MeV],      default/current value = "
                    << beam_energy << G4endl;
 
-            G4cout << "--energyDistFlat <double>[MeV]:<double>[MeV] : Use a flat energy distribution, "
+            G4cout << "--energyDistFlat <double>[MeV]:<double>[MeV] : Use a flat kinetic energy distribution, "
                    << "between the two limits. If used, -e will just be reference energy. Current min/max: "
                    << beam_eFlat_min << ", " << beam_eFlat_max << G4endl;
 

--- a/include/PrimaryGeneratorAction.hh
+++ b/include/PrimaryGeneratorAction.hh
@@ -63,7 +63,7 @@ private:
     G4ParticleGun*           particleGun;  //pointer a to G4 class
     DetectorConstruction*    Detector;     //pointer to the geometry
 
-    G4double beam_energy;    // Beam energy [MeV]
+    G4double beam_energy;    // Beam kinetic energy [MeV]
 
     G4String beam_type;      // Beam particle type
     G4double beam_offset;    // Beam offset (x) [mm]

--- a/src/PrimaryGeneratorAction.cc
+++ b/src/PrimaryGeneratorAction.cc
@@ -135,10 +135,13 @@ void PrimaryGeneratorAction::setupCovariance() {
     }
 
     //Compute the geometrical emittance
-    G4double gamma_rel = beam_energy*MeV/particle->GetPDGMass();
-    G4cout << "gamma_rel = " << gamma_rel << G4endl;
+    G4cout << "beam_energy       = " << beam_energy/MeV << G4endl;
+    G4double beam_total_energy = beam_energy + particle->GetPDGMass();
+    G4cout << "beam_total_energy = " << beam_total_energy/MeV << G4endl;
+    G4double gamma_rel = beam_total_energy/particle->GetPDGMass();
+    G4cout << "gamma_rel         = " << gamma_rel << G4endl;
     G4double beta_rel = sqrt(gamma_rel*gamma_rel - 1.0) / gamma_rel;
-    G4cout << "beta_rel = " << beta_rel << G4endl;
+    G4cout << "beta_rel          = " << beta_rel << G4endl;
 
     epsG_x = epsN_x / (beta_rel*gamma_rel);
     epsG_y = epsN_y / (beta_rel*gamma_rel);
@@ -337,6 +340,6 @@ void PrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent) {
     else {
         E = beam_energy*MeV;
     }
-    particleGun->SetParticleEnergy(E);
+    particleGun->SetParticleEnergy(E); //Setting the kinetic energy (E>0 is valid)
     particleGun->GeneratePrimaryVertex(anEvent);
 }

--- a/src/PrimaryGeneratorAction.cc
+++ b/src/PrimaryGeneratorAction.cc
@@ -135,8 +135,8 @@ void PrimaryGeneratorAction::setupCovariance() {
     }
 
     //Compute the geometrical emittance
-    G4cout << "beam_energy       = " << beam_energy/MeV << G4endl;
-    G4double beam_total_energy = beam_energy + particle->GetPDGMass();
+    G4cout << "beam_energy       = " << beam_energy << " [MeV]" << G4endl;
+    G4double beam_total_energy = beam_energy*MeV + particle->GetPDGMass();
     G4cout << "beam_total_energy = " << beam_total_energy/MeV << G4endl;
     G4double gamma_rel = beam_total_energy/particle->GetPDGMass();
     G4cout << "gamma_rel         = " << gamma_rel << G4endl;

--- a/src/RootFileWriter.cc
+++ b/src/RootFileWriter.cc
@@ -1717,7 +1717,7 @@ void RootFileWriter::PrintTwissParameters(TH2D* phaseSpaceHist) {
 
     G4RunManager*           run    = G4RunManager::GetRunManager();
     PrimaryGeneratorAction* genAct = (PrimaryGeneratorAction*)run->GetUserPrimaryGeneratorAction();
-    double gamma_rel = (genAct->get_beam_energy() * MeV) / genAct->get_beam_particlemass();
+    double gamma_rel = 1 + ( genAct->get_beam_energy() * MeV / genAct->get_beam_particlemass() );
     double beta_rel = sqrt(gamma_rel*gamma_rel - 1.0) / gamma_rel;
 
     double det = posVar*angVar - coVar*coVar;
@@ -1726,10 +1726,10 @@ void RootFileWriter::PrintTwissParameters(TH2D* phaseSpaceHist) {
     double beta = posVar/epsG; // [mm]
     double alpha = -coVar/epsG;
 
-    G4cout << "Geometrical emittance  = " << epsG*1e3 << " [um]" << G4endl;
-    G4cout << "Normalized emittance   = " << epsN*1e3 << " [um]"
-           << ", assuming beam energy = " << genAct->get_beam_energy() << " [MeV]"
-           << ", and mass = " << genAct->get_beam_particlemass()/MeV << " [MeV/c]"
+    G4cout << "Geometrical emittance          = " << epsG*1e3 << " [um]" << G4endl;
+    G4cout << "Normalized emittance           = " << epsN*1e3 << " [um]"
+           << ", assuming beam kinetic energy = " << genAct->get_beam_energy() << " [MeV]"
+           << ", and mass = " << genAct->get_beam_particlemass()/MeV << " [MeV/c^2]"
            << G4endl;
     G4cout << "Twiss beta  = " << beta*1e-3  << " [m]" << G4endl
            << "Twiss alpha = " << alpha << " [-]"  << G4endl;


### PR DESCRIPTION
For Twiss parameters, the kinetic energy was used as the total energy. This caused the computation to fail for Lorentz factor < 1. Accuracy was still acceptable for high Lorentz factors (electron beams...).