### PR TITLE
Add TWISS output from Python for magnets

### DIFF
--- a/scripts/miniScatterDriver.py
+++ b/scripts/miniScatterDriver.py
@@ -256,6 +256,13 @@ def getData(filename="plots/output.root", quiet=False, getRaw=False, getObjects=
     else:
         _twissDets   = twissDets
         _numPartDets = numPartDets
+    i = 1
+    while dataFile.GetListOfKeys().Contains("magnet_{}_x_TWISS".format(i)):
+        print("found magnet_{}".format(i))
+        _twissDets   = _twissDets   + ("magnet_{}".format(i), "magnet_{}_cutoff".format(i))
+        _numPartDets = _numPartDets + ("magnet_{}".format(i), "magnet_{}_cutoff".format(i))
+
+        i = i+1
 
     twiss = {}
     for det in _twissDets:
@@ -285,7 +292,7 @@ def getData(filename="plots/output.root", quiet=False, getRaw=False, getObjects=
         numPart_PDG = dataFile.Get(det+"_ParticleTypes_PDG")
         numPart_num = dataFile.Get(det+"_ParticleTypes_numpart")
         for i in range(len(numPart_PDG)):
-            numPart[det][int(numPart_PDG[i])] = numPart_num[i]
+            numPart[det][int(numPart_PDG[i])] = int(numPart_num[i])
 
     objects = None
     if getObjects:

--- a/scripts/miniScatterPlots.py
+++ b/scripts/miniScatterPlots.py
@@ -43,7 +43,7 @@ def plotRZgray(objects, nevents_simulated, nparts_actual,forcePython=False,magne
         rzScaled = ROOT.TH2D(objects[magnetName +'_edep_rdens']) #[MeV/bin]
         density  = objects[magnetName + '_metadata'][0] #[g/cm^3]
 
-    scaleFactor_energyUnit = 1.6021766e-13; #J/MeV
+    scaleFactor_energyUnit = 1.6021766e-13  #J/MeV
     scaleFactor_nPart = nparts_actual/nevents_simulated
 
     #Try to use the C++ implementation of the algorithm, for the speeds


### PR DESCRIPTION
When running with magnets (not just target), TWISS output is also generated into the ROOT file.
This allows MiniScatterDriver.getData(), and it's derived functions, to pick this up.