### PR TITLE
Add material 'Diamond'

### DIFF
--- a/MiniScatter.cc
+++ b/MiniScatter.cc
@@ -954,7 +954,7 @@ void printHelp(G4double target_thick,
                    << "\t Valid choices: 'G4_Al', 'G4_Au','G4_C', 'G4_Cu', 'G4_Pb', 'G4_Ti', 'G4_Si', 'G4_W', 'G4_U', 'G4_Fe'," << G4endl
                    << "\t                'G4_MYLAR', 'G4_KAPTON', 'G4_STAINLESS-STEEL', 'G4_WATER', 'G4_SODIUM_IODIDE', 'G4_POLYPROPYLENE'" << G4endl
 		   << "\t                'G4_Galactic', 'G4_AIR'," << G4endl
-                   << "\t                'Sapphire', 'ChromoxPure', 'ChromoxScreen'." << G4endl
+                   << "\t                'Sapphire', 'Diamond', 'ChromoxPure', 'ChromoxScreen'." << G4endl
                    << "\t Also possible: 'gas::pressure' " << G4endl
                    << "\t                where 'gas' is 'H_2', 'He', 'N_2', 'Ne', or 'Ar'," << G4endl
                    << "\t                and pressure is given in mbar (T=300K is assumed)."  << G4endl
@@ -1050,7 +1050,7 @@ void printHelp(G4double target_thick,
                    << "\t Angles with absolute value >= 90 degrees are not accepted." << G4endl
                    << "\t Currently not compatible with --xoffset, --covar, --beamRcut, or backtracking from * in --zoffset." << G4endl
                    << "\t Note that the absolute value of --zoffset (which is generally negative)" << G4endl
-                   << "\t will mean the distance from x=y=z=0 to the starting point."
+                   << "\t will mean the distance from x=y=z=0 to the starting point." << G4endl
                    << "\t Default/current value = " << beam_angle << G4endl << G4endl;
 
             G4cout << " --covar/-c epsN[um]:beta[m]:alpha(::epsN_Y[um]:betaY[m]:alphaY)" << G4endl

--- a/include/DetectorConstruction.hh
+++ b/include/DetectorConstruction.hh
@@ -97,6 +97,8 @@ private:
 
     G4Material*        SapphireMaterial       = NULL;
 
+    G4Material*        DiamondMaterial        = NULL;
+
     G4Material*        ChromoxMaterial        = NULL;
     G4Material*        ChromoxScreenMaterial  = NULL;
 

--- a/include/MiniScatterVersion.hh
+++ b/include/MiniScatterVersion.hh
@@ -1,7 +1,7 @@
 #ifndef MINISCATTERVERSION_HH
 #define MINISCATTERVERSION_HH 1
 
-inline const char* const miniscatter_version = "1.3-4";
-inline const char* const miniscatter_date    = "Nov 5th 2024";
+inline const char* const miniscatter_version = "1.3-5";
+inline const char* const miniscatter_date    = "March 11th 2026";
 
 #endif

--- a/src/DetectorConstruction.cc
+++ b/src/DetectorConstruction.cc
@@ -247,7 +247,7 @@ void DetectorConstruction::DefineMaterials() {
     man->SetVerbose(1);
 
     AlMaterial = man->FindOrBuildMaterial("G4_Al");
-    CuMaterial = man->FindOrBuildMaterial("G4_C");
+    CMaterial  = man->FindOrBuildMaterial("G4_C");
     CuMaterial = man->FindOrBuildMaterial("G4_Cu");
     PbMaterial = man->FindOrBuildMaterial("G4_Pb");
     TiMaterial = man->FindOrBuildMaterial("G4_Ti");
@@ -272,6 +272,8 @@ void DetectorConstruction::DefineMaterials() {
     SapphireMaterial = new G4Material("Sapphire", 4.0*g/cm3, 2);
     SapphireMaterial->AddElement(elAl, 2);
     SapphireMaterial->AddElement(elO,  3);
+
+    G4Material* DiamondMaterial = new G4Material("Diamond", 6, 12.01*g/mole, 3.515*g/cm3);
 
     G4Element* elCr = new G4Element("Chromium", "Cr", 24.0, 51.9961*g/mole);
     ChromoxMaterial = new G4Material("ChromoxPure",5.22*g/cm3,2);


### PR DESCRIPTION
Diamond material is a clone of a G4 example: https://github.com/Geant4/geant4/blob/b4a16de652ec244f7a0ecc0a5cacfee21930bf75/examples/advanced/exp_microdosimetry/src/DetectorConstruction.cc#L223

Also fix G4_C, which was mis-defined, and fix a small typo in the help text.